### PR TITLE
Fix "Suggest An Edit" link

### DIFF
--- a/src/lib/layouts/post.svelte
+++ b/src/lib/layouts/post.svelte
@@ -358,7 +358,7 @@
     </span>
     <a
       class="post__edit"
-      href="https://github.com/elianiva/elianiva.my.id/blob/master/src/routes/post{currentSlug}/index.svx"
+      href="https://github.com/elianiva/elianiva.my.id/blob/master/src/routes{currentSlug}/index.svx"
       target="_blank"
       rel="norel noreferrer">Suggest An Edit</a
     >


### PR DESCRIPTION
On `https://elianiva.my.id/post/a-year-of-japanese`, the link is rendered as `https://github.com/elianiva/elianiva.my.id/blob/master/src/routes/post/post/a-year-of-japanese/index.svx`.