### PR TITLE
fix: little typo on bio

### DIFF
--- a/src/lib/parts/Header.svelte
+++ b/src/lib/parts/Header.svelte
@@ -29,7 +29,7 @@
       class="relative block font-sans text-clamped-sm leading-normal mb-4 text-slate-700 dark:text-slate-400"
     >
       I like to write code and contribute to open source projects, and sometimes
-      write something in this blog. I speak Indonesia, English, and a little bit
+      write something in this blog. I speak Indonesian, English, and a little bit
       of Japanese. Feel free to hit me up!
     </p>
   </div>


### PR DESCRIPTION
Hi, awesome website!

I think I spotted a typo on you bio. It says "I speak Indonesia", but in English, **Indonesia** refers to the country and **Indonesian** to the language. ([Indonesia](https://dictionary.cambridge.org/dictionary/english/indonesia) vs [Indonesian](https://dictionary.cambridge.org/dictionary/english/indonesian) on the Cambridge Dictionary)

I definitely don't talk Indonesian, so let me know if this is right :)