### PR TITLE
fix(ProjectLayout): cover image extension to webp

### DIFF
--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -30,7 +30,7 @@ const { frontmatter, slug } = Astro.props as Props;
 			<div class="overflow-hidden border border-dashed border-pink-300 rounded-md overflow-hidden">
 				{frontmatter.hasImage ? (
 					<img
-						src={`/assets/projects/${slug}/cover.jpg`}
+						src={`/assets/projects/${slug}/cover.webp`}
 						alt={frontmatter.title}
 						class="block w-full h-full bg-pink-100"
 						loading="lazy"


### PR DESCRIPTION
Small fix for projects cover image, it was .jpg :/

![image](https://github.com/elianiva/elianiva.my.id/assets/31957516/04b6cb53-55f0-480c-ba9c-435108abab9b)
