### PR TITLE
[deps] lucide-react@1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "effect": "4.0.0-beta.68",
     "force-graph": "^1.51.4",
     "gray-matter": "^4.0.3",
-    "lucide-react": "^1.16.0",
+    "lucide-react": "^1.22.0",
     "motion": "^12.39.0",
     "octokit": "^5.0.5",
     "react": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       lucide-react:
-        specifier: ^1.16.0
-        version: 1.16.0(react@19.2.6)
+        specifier: ^1.22.0
+        version: 1.22.0(react@19.2.6)
       motion:
         specifier: ^12.39.0
         version: 12.39.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -4152,8 +4152,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.16.0:
-    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+  lucide-react@1.22.0:
+    resolution: {integrity: sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -9367,7 +9367,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.16.0(react@19.2.6):
+  lucide-react@1.22.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 


### PR DESCRIPTION
## Summary

Upgrade lucide-react from 1.16.0 to 1.22.0.

### Changes
- Updated `lucide-react` version from `^1.16.0` to `^1.22.0` in `package.json`
- Updated `pnpm-lock.yaml`

### What's New
- 30+ new icons across 6 releases (star variants, database variants, `broken-bone`, `golden-ratio`, etc.)
- Visual fixes to existing icons (`martini`, `wallet-cards`, `square-arrow-*`, `carrot`, `ungroup`)
- Internal maintenance and CI/CD improvements

### Verification
- ✅ `pnpm install` succeeds
- ✅ `pnpm exec tsc --noEmit` — no new errors (only pre-existing)
- ✅ `oxlint .` — 0 warnings, 0 errors
- ✅ No breaking changes — all existing icon imports remain compatible

Closes #68

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `lucide-react` from 1.16.0 to 1.22.0
> Updates the version constraint in [package.json](https://github.com/elianiva/elianiva.com/pull/86/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and regenerates the lockfile to resolve 1.22.x.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fb345b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->