### PR TITLE
feat: port background to WebGPU with WebGL2 fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",
+    "@webgpu/types": "^0.1.71",
     "babel-plugin-react-compiler": "^1.0.0",
     "jsdom": "^29.1.1",
     "mdx": "^0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.4
         version: 6.0.4(@voidzero-dev/vite-plus-core@0.2.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0))(babel-plugin-react-compiler@1.0.0)
+      '@webgpu/types':
+        specifier: ^0.1.71
+        version: 0.1.71
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3013,6 +3016,9 @@ packages:
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [win32]
+
+  '@webgpu/types@0.1.71':
+    resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
 
   '@yuku-codegen/binding-darwin-arm64@0.5.48':
     resolution: {integrity: sha512-yo96Oef12WzqnphInfz/eexVse3+kWgfGS5g2S3rFS3dcGn1ENW9xLFDZUP9rh+yP76DOq38wBoFi1+I9+6qBg==}
@@ -8846,6 +8852,8 @@ snapshots:
 
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.5':
     optional: true
+
+  '@webgpu/types@0.1.71': {}
 
   '@yuku-codegen/binding-darwin-arm64@0.5.48':
     optional: true

--- a/src/components/canvas-background.tsx
+++ b/src/components/canvas-background.tsx
@@ -1,198 +1,83 @@
-import { useRef, useEffect } from "react";
-import fragSource from "~/shaders/bg.frag.glsl?raw";
-import vertSource from "~/shaders/bg.vert.glsl?raw";
+import { useEffect, useRef, useState } from "react";
+import type { BackgroundRenderer } from "~/lib/background";
+import { computeCanvasSize, generateShapes } from "~/lib/background";
+import { createWebGLRenderer } from "~/lib/webgl-background";
+import { createWebGPURenderer } from "~/lib/webgpu-background";
 
-const SCALE = 0.5;
 const TARGET_FPS = 30;
 const FRAME_INTERVAL = 1000 / TARGET_FPS;
-const UPDATE_EVERY = 1;
+const MAX_LOSSES_BEFORE_FALLBACK = 2;
 
-const N = 10;
-const COLS = 4;
-const ROWS = 3;
-
-const PALETTE = [
-  [0.88, 0.72, 0.78],
-  [0.82, 0.78, 0.86],
-  [0.9, 0.82, 0.8],
-  [0.85, 0.74, 0.82],
-  [0.92, 0.76, 0.8],
-  [0.8, 0.76, 0.88],
-];
-
-function shuffle<T>(arr: T[]): T[] {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [arr[i], arr[j]] = [(arr as any)[j], (arr as any)[i]];
-  }
-  return arr;
+interface MountState {
+  key: number;
+  webgl: boolean;
 }
 
 export function CanvasBackground() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [mount, setMount] = useState<MountState>({ key: 0, webgl: false });
 
   useEffect(() => {
-    const canvas = canvasRef.current;
+    const canvas = canvasRef.current!;
     if (!canvas) return;
 
-    const gl = canvas.getContext("webgl2", {
-      alpha: false,
-      antialias: false,
-      preserveDrawingBuffer: false,
-    });
-    if (!gl) return;
-
     const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const shapes = generateShapes();
 
-    function compile(type: number, source: string) {
-      const s = gl!.createShader(type);
-      if (!s) return null;
-      gl!.shaderSource(s, source);
-      gl!.compileShader(s);
-      if (!gl!.getShaderParameter(s, gl!.COMPILE_STATUS)) {
-        console.error(gl!.getShaderInfoLog(s));
-        gl!.deleteShader(s);
-        return null;
-      }
-      return s;
-    }
-
-    const vs = compile(gl.VERTEX_SHADER, vertSource);
-    const fs = compile(gl.FRAGMENT_SHADER, fragSource);
-    if (!vs || !fs) return;
-
-    const prog = gl.createProgram();
-    if (!prog) return;
-    gl.attachShader(prog, vs);
-    gl.attachShader(prog, fs);
-    gl.linkProgram(prog);
-    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
-      console.error(gl.getProgramInfoLog(prog));
-      return;
-    }
-    gl.useProgram(prog);
-
-    const buf = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
-    const aPos = gl.getAttribLocation(prog, "a_pos");
-    gl.enableVertexAttribArray(aPos);
-    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
-
-    // --- generate shapes evenly across grid cells ---
-    const cells: { x: number; y: number }[] = [];
-    for (let y = 0; y < ROWS; y++) {
-      for (let x = 0; x < COLS; x++) {
-        cells.push({ x, y });
-      }
-    }
-    shuffle(cells);
-
-    const pos = new Float32Array(N * 2);
-    const dir = new Float32Array(N * 2);
-    const driftSpeed = new Float32Array(N);
-    const driftOffset = new Float32Array(N);
-    const rotSpeed = new Float32Array(N);
-    const size = new Float32Array(N);
-    const kind = new Float32Array(N);
-    const filled = new Float32Array(N);
-    const aspect = new Float32Array(N * 2);
-    const color = new Float32Array(N * 3);
-    const breatheSpeed = new Float32Array(N);
-    const breathePhase = new Float32Array(N);
-    const baseAlpha = new Float32Array(N);
-
-    for (let i = 0; i < N; i++) {
-      const cell = cells[i];
-      const cx = (cell.x + 0.5) / COLS;
-      const cy = (cell.y + 0.5) / ROWS;
-      const jx = ((Math.random() - 0.5) * 0.5) / COLS;
-      const jy = ((Math.random() - 0.5) * 0.5) / ROWS;
-      pos[i * 2] = cx + jx;
-      pos[i * 2 + 1] = cy + jy;
-
-      const angle = Math.random() * Math.PI * 2;
-      dir[i * 2] = Math.cos(angle);
-      dir[i * 2 + 1] = Math.sin(angle);
-
-      driftSpeed[i] = 0.02 + Math.random() * 0.03;
-      driftOffset[i] = Math.random() * 10.0;
-      rotSpeed[i] = (Math.random() - 0.5) * 0.4;
-      size[i] = 0.025 + Math.random() * 0.045;
-      kind[i] = Math.random() > 0.7 ? 1.0 : 0.0;
-      filled[i] = Math.random() > 0.4 ? 1.0 : 0.0;
-
-      if (kind[i] < 0.5) {
-        aspect[i * 2] = 0.5 + Math.random() * 1.0;
-        aspect[i * 2 + 1] = 0.6 + Math.random() * 0.8;
-      } else {
-        aspect[i * 2] = 1.0;
-        aspect[i * 2 + 1] = 1.0;
-      }
-
-      const pal = PALETTE[Math.floor(Math.random() * PALETTE.length)];
-      color[i * 3] = pal[0];
-      color[i * 3 + 1] = pal[1];
-      color[i * 3 + 2] = pal[2];
-
-      breatheSpeed[i] = 0.4 + Math.random() * 0.6;
-      breathePhase[i] = Math.random() * Math.PI * 2;
-      baseAlpha[i] = 0.15 + Math.random() * 0.08;
-    }
-
-    // --- uniform locations ---
-    const uTime = gl.getUniformLocation(prog, "u_time");
-    const uRes = gl.getUniformLocation(prog, "u_res");
-    const uPos = gl.getUniformLocation(prog, "u_pos");
-    const uDir = gl.getUniformLocation(prog, "u_dir");
-    const uDriftSpeed = gl.getUniformLocation(prog, "u_driftSpeed");
-    const uDriftOffset = gl.getUniformLocation(prog, "u_driftOffset");
-    const uRotSpeed = gl.getUniformLocation(prog, "u_rotSpeed");
-    const uSize = gl.getUniformLocation(prog, "u_size");
-    const uKind = gl.getUniformLocation(prog, "u_kind");
-    const uFilled = gl.getUniformLocation(prog, "u_filled");
-    const uAspect = gl.getUniformLocation(prog, "u_aspect");
-    const uColor = gl.getUniformLocation(prog, "u_color");
-    const uBreatheSpeed = gl.getUniformLocation(prog, "u_breatheSpeed");
-    const uBreathePhase = gl.getUniformLocation(prog, "u_breathePhase");
-    const uBaseAlpha = gl.getUniformLocation(prog, "u_baseAlpha");
-
-    // --- upload once ---
-    gl.uniform2fv(uPos, pos);
-    gl.uniform2fv(uDir, dir);
-    gl.uniform1fv(uDriftSpeed, driftSpeed);
-    gl.uniform1fv(uDriftOffset, driftOffset);
-    gl.uniform1fv(uRotSpeed, rotSpeed);
-    gl.uniform1fv(uSize, size);
-    gl.uniform1fv(uKind, kind);
-    gl.uniform1fv(uFilled, filled);
-    gl.uniform2fv(uAspect, aspect);
-    gl.uniform3fv(uColor, color);
-    gl.uniform1fv(uBreatheSpeed, breatheSpeed);
-    gl.uniform1fv(uBreathePhase, breathePhase);
-    gl.uniform1fv(uBaseAlpha, baseAlpha);
-
+    let renderer: BackgroundRenderer | null = null;
+    let raf = 0;
     let running = true;
-    let raf: number;
+    let starting = false;
+    let pendingLost: boolean | null = null;
+    let disposed = false;
+    let losses = 0;
+    let backend: "webgpu" | "webgl" = "webgl";
     let startTime = performance.now();
     let lastFrameTime = 0;
-    let frameCount = 0;
-    let needsDraw = true;
+    let currentTime = 0;
+    let size = { width: 0, height: 0 };
+    let pendingSize: { width: number; height: number } | null = null;
+    let resizeTimer = 0;
+
+    function applyResize(target: { width: number; height: number }) {
+      if (target.width === size.width && target.height === size.height) return;
+      size = target;
+      renderer?.resize(target.width, target.height);
+      renderer?.frame(prefersReducedMotion ? 0 : currentTime);
+    }
 
     function resize() {
-      const c = canvas!;
-      const w = c.clientWidth;
-      const h = c.clientHeight;
-      c.width = Math.max(1, Math.floor(w * SCALE));
-      c.height = Math.max(1, Math.floor(h * SCALE));
-      gl!.viewport(0, 0, c.width, c.height);
-      gl!.uniform2f(uRes, c.width, c.height);
-      needsDraw = true;
+      const target = computeCanvasSize(canvas.clientWidth, canvas.clientHeight);
+      if (target.width === size.width && target.height === size.height) {
+        pendingSize = null;
+        if (resizeTimer) {
+          window.clearTimeout(resizeTimer);
+          resizeTimer = 0;
+        }
+        return;
+      }
+      pendingSize = target;
+      // Apply big changes (initial load, orientation) immediately. Small
+      // changes during scroll are the mobile URL bar resizing the viewport;
+      // deferring them keeps the buffer (and the shader's aspect) stable
+      // until the viewport settles, avoiding shape jumps.
+      const changed = Math.max(
+        Math.abs(target.width - size.width) / Math.max(size.width, 1),
+        Math.abs(target.height - size.height) / Math.max(size.height, 1),
+      );
+      if (size.width === 0 || changed > 0.2) {
+        applyResize(target);
+        return;
+      }
+      if (resizeTimer) window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(() => {
+        resizeTimer = 0;
+        if (pendingSize) applyResize(pendingSize);
+      }, 200);
     }
 
     function render(now: number) {
-      if (!running) return;
+      if (!running || disposed) return;
 
       if (now - lastFrameTime < FRAME_INTERVAL) {
         raf = requestAnimationFrame(render);
@@ -201,33 +86,103 @@ export function CanvasBackground() {
       lastFrameTime = now;
 
       if (prefersReducedMotion) {
-        gl!.uniform1f(uTime, 0);
-        gl!.drawArrays(gl!.TRIANGLES, 0, 3);
+        try {
+          renderer?.frame(0);
+        } catch (error) {
+          console.error("background render error", error);
+          handleLost(backend === "webgl");
+        }
         return;
       }
 
-      const t = (now - startTime) * 0.001;
-      gl!.uniform1f(uTime, t);
-
-      if (needsDraw || frameCount % UPDATE_EVERY === 0) {
-        gl!.drawArrays(gl!.TRIANGLES, 0, 3);
-        needsDraw = false;
+      currentTime = (now - startTime) * 0.001;
+      try {
+        renderer?.frame(currentTime);
+      } catch (error) {
+        console.error("background render error", error);
+        handleLost(backend === "webgl");
+        return;
       }
-      frameCount++;
-
       raf = requestAnimationFrame(render);
     }
 
-    resize();
+    async function start(preferWebGL: boolean) {
+      if (starting || disposed) return;
+      starting = true;
+      try {
+        let next: BackgroundRenderer | null = null;
+        if (!preferWebGL && navigator.gpu) {
+          try {
+            const adapter = await navigator.gpu.requestAdapter();
+            if (adapter) {
+              next = await createWebGPURenderer(canvas, shapes, onWebGPULost);
+            }
+          } catch (error) {
+            console.error("WebGPU init failed, falling back to WebGL", error);
+          }
+        }
+        if (disposed) {
+          next?.destroy();
+          return;
+        }
+        if (!next) {
+          // A webgpu context already claimed this canvas, so a fresh canvas is
+          // needed before WebGL can take it.
+          if (!preferWebGL && canvas.getContext("webgpu")) {
+            setMount((m) => ({ key: m.key + 1, webgl: true }));
+            return;
+          }
+          next = createWebGLRenderer(canvas, shapes, onWebGLLost);
+        }
+        backend = preferWebGL ? "webgl" : "webgpu";
+        renderer = next;
+        resize();
+        if (running) {
+          lastFrameTime = 0;
+          raf = requestAnimationFrame(render);
+        }
+      } finally {
+        starting = false;
+        if (pendingLost !== null) {
+          const lostPreferWebGL = pendingLost;
+          pendingLost = null;
+          handleLost(lostPreferWebGL);
+        }
+      }
+    }
+
+    function handleLost(preferWebGL: boolean) {
+      if (disposed) return;
+      if (starting) {
+        pendingLost = preferWebGL;
+        return;
+      }
+      if (!preferWebGL) losses++;
+      renderer?.destroy();
+      renderer = null;
+      cancelAnimationFrame(raf);
+      if (!preferWebGL && losses >= MAX_LOSSES_BEFORE_FALLBACK) {
+        setMount((m) => ({ key: m.key + 1, webgl: true }));
+        return;
+      }
+      void start(preferWebGL);
+    }
+
+    function onWebGPULost() {
+      handleLost(false);
+    }
+
+    function onWebGLLost() {
+      handleLost(true);
+    }
+
     window.addEventListener("resize", resize);
-    raf = requestAnimationFrame(render);
 
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries[0].isIntersecting;
-        if (visible && !running) {
+        const visible = entries[0]!.isIntersecting;
+        if (visible && !running && renderer) {
           running = true;
-          needsDraw = true;
           lastFrameTime = 0;
           raf = requestAnimationFrame(render);
         } else if (!visible && running) {
@@ -239,20 +194,22 @@ export function CanvasBackground() {
     );
     observer.observe(canvas);
 
+    void start(mount.webgl);
+
     return () => {
+      disposed = true;
       running = false;
       cancelAnimationFrame(raf);
+      if (resizeTimer) window.clearTimeout(resizeTimer);
       observer.disconnect();
       window.removeEventListener("resize", resize);
-      gl.deleteProgram(prog);
-      gl.deleteShader(vs);
-      gl.deleteShader(fs);
-      gl.deleteBuffer(buf);
+      renderer?.destroy();
     };
-  }, []);
+  }, [mount.key, mount.webgl]);
 
   return (
     <canvas
+      key={mount.key}
       ref={canvasRef}
       className="fixed inset-0 w-full h-full pointer-events-none -z-10"
       style={{ imageRendering: "auto" }}

--- a/src/components/canvas-background.tsx
+++ b/src/components/canvas-background.tsx
@@ -32,6 +32,9 @@ export function CanvasBackground() {
     let disposed = false;
     let losses = 0;
     let backend: "webgpu" | "webgl" = "webgl";
+    let webgpuContextClaimed = false;
+    let restoreHandler: (() => void) | null = null;
+    let restoreTimer = 0;
     let startTime = performance.now();
     let lastFrameTime = 0;
     let currentTime = 0;
@@ -111,13 +114,19 @@ export function CanvasBackground() {
       starting = true;
       try {
         let next: BackgroundRenderer | null = null;
+        let nextBackend: "webgpu" | "webgl" = "webgl";
         if (!preferWebGL && navigator.gpu) {
           try {
             const adapter = await navigator.gpu.requestAdapter();
             if (adapter) {
               next = await createWebGPURenderer(canvas, shapes, onWebGPULost);
+              webgpuContextClaimed = next !== null;
+              nextBackend = "webgpu";
             }
           } catch (error) {
+            // The webgpu context may have been claimed before the failure, so
+            // fall back on a fresh canvas rather than blocking WebGL.
+            webgpuContextClaimed = true;
             console.error("WebGPU init failed, falling back to WebGL", error);
           }
         }
@@ -126,15 +135,14 @@ export function CanvasBackground() {
           return;
         }
         if (!next) {
-          // A webgpu context already claimed this canvas, so a fresh canvas is
-          // needed before WebGL can take it.
-          if (!preferWebGL && canvas.getContext("webgpu")) {
+          if (webgpuContextClaimed) {
             setMount((m) => ({ key: m.key + 1, webgl: true }));
             return;
           }
           next = createWebGLRenderer(canvas, shapes, onWebGLLost);
+          nextBackend = "webgl";
         }
-        backend = preferWebGL ? "webgl" : "webgpu";
+        backend = nextBackend;
         renderer = next;
         resize();
         if (running) {
@@ -151,6 +159,30 @@ export function CanvasBackground() {
       }
     }
 
+    function restartWebGL() {
+      // A lost WebGL context is unusable until the browser fires
+      // 'webglcontextrestored', so recreate the renderer then. Fall back to a
+      // timed retry in case restoration never fires.
+      const onRestored = () => {
+        canvas.removeEventListener("webglcontextrestored", onRestored);
+        if (restoreHandler === onRestored) restoreHandler = null;
+        if (restoreTimer) {
+          window.clearTimeout(restoreTimer);
+          restoreTimer = 0;
+        }
+        if (disposed) return;
+        void start(true);
+      };
+      restoreHandler = onRestored;
+      canvas.addEventListener("webglcontextrestored", onRestored);
+      restoreTimer = window.setTimeout(() => {
+        restoreTimer = 0;
+        canvas.removeEventListener("webglcontextrestored", onRestored);
+        if (restoreHandler === onRestored) restoreHandler = null;
+        if (!disposed) void start(true);
+      }, 3000);
+    }
+
     function handleLost(preferWebGL: boolean) {
       if (disposed) return;
       if (starting) {
@@ -161,11 +193,22 @@ export function CanvasBackground() {
       renderer?.destroy();
       renderer = null;
       cancelAnimationFrame(raf);
+      // Reset the cached size so the next renderer receives its dimensions.
+      size = { width: 0, height: 0 };
+      pendingSize = null;
+      if (resizeTimer) {
+        window.clearTimeout(resizeTimer);
+        resizeTimer = 0;
+      }
       if (!preferWebGL && losses >= MAX_LOSSES_BEFORE_FALLBACK) {
         setMount((m) => ({ key: m.key + 1, webgl: true }));
         return;
       }
-      void start(preferWebGL);
+      if (preferWebGL) {
+        restartWebGL();
+        return;
+      }
+      void start(false);
     }
 
     function onWebGPULost() {
@@ -201,6 +244,8 @@ export function CanvasBackground() {
       running = false;
       cancelAnimationFrame(raf);
       if (resizeTimer) window.clearTimeout(resizeTimer);
+      if (restoreTimer) window.clearTimeout(restoreTimer);
+      if (restoreHandler) canvas.removeEventListener("webglcontextrestored", restoreHandler);
       observer.disconnect();
       window.removeEventListener("resize", resize);
       renderer?.destroy();

--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -1,0 +1,136 @@
+export const N = 10;
+export const COLS = 4;
+export const ROWS = 3;
+
+const PALETTE = [
+  [0.88, 0.72, 0.78],
+  [0.82, 0.78, 0.86],
+  [0.9, 0.82, 0.8],
+  [0.85, 0.74, 0.82],
+  [0.92, 0.76, 0.8],
+  [0.8, 0.76, 0.88],
+];
+
+export interface ShapeParams {
+  pos: Float32Array;
+  dir: Float32Array;
+  driftSpeed: Float32Array;
+  driftOffset: Float32Array;
+  rotSpeed: Float32Array;
+  size: Float32Array;
+  kind: Float32Array;
+  filled: Float32Array;
+  aspect: Float32Array;
+  color: Float32Array;
+  breatheSpeed: Float32Array;
+  breathePhase: Float32Array;
+  baseAlpha: Float32Array;
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]!];
+  }
+  return arr;
+}
+
+export function generateShapes(): ShapeParams {
+  const cells: { x: number; y: number }[] = [];
+  for (let y = 0; y < ROWS; y++) {
+    for (let x = 0; x < COLS; x++) {
+      cells.push({ x, y });
+    }
+  }
+  shuffle(cells);
+
+  const pos = new Float32Array(N * 2);
+  const dir = new Float32Array(N * 2);
+  const driftSpeed = new Float32Array(N);
+  const driftOffset = new Float32Array(N);
+  const rotSpeed = new Float32Array(N);
+  const size = new Float32Array(N);
+  const kind = new Float32Array(N);
+  const filled = new Float32Array(N);
+  const aspect = new Float32Array(N * 2);
+  const color = new Float32Array(N * 3);
+  const breatheSpeed = new Float32Array(N);
+  const breathePhase = new Float32Array(N);
+  const baseAlpha = new Float32Array(N);
+
+  for (let i = 0; i < N; i++) {
+    const cell = cells[i]!;
+    const cx = (cell.x + 0.5) / COLS;
+    const cy = (cell.y + 0.5) / ROWS;
+    const jx = ((Math.random() - 0.5) * 0.5) / COLS;
+    const jy = ((Math.random() - 0.5) * 0.5) / ROWS;
+    pos[i * 2] = cx + jx;
+    pos[i * 2 + 1] = cy + jy;
+
+    const angle = Math.random() * Math.PI * 2;
+    dir[i * 2] = Math.cos(angle);
+    dir[i * 2 + 1] = Math.sin(angle);
+
+    driftSpeed[i] = 0.02 + Math.random() * 0.03;
+    driftOffset[i] = Math.random() * 10.0;
+    rotSpeed[i] = (Math.random() - 0.5) * 0.4;
+    size[i] = 0.025 + Math.random() * 0.045;
+    kind[i] = Math.random() > 0.7 ? 1.0 : 0.0;
+    filled[i] = Math.random() > 0.4 ? 1.0 : 0.0;
+
+    if (kind[i] < 0.5) {
+      aspect[i * 2] = 0.5 + Math.random() * 1.0;
+      aspect[i * 2 + 1] = 0.6 + Math.random() * 0.8;
+    } else {
+      aspect[i * 2] = 1.0;
+      aspect[i * 2 + 1] = 1.0;
+    }
+
+    const pal = PALETTE[Math.floor(Math.random() * PALETTE.length)]!;
+    color[i * 3] = pal[0];
+    color[i * 3 + 1] = pal[1];
+    color[i * 3 + 2] = pal[2];
+
+    breatheSpeed[i] = 0.4 + Math.random() * 0.6;
+    breathePhase[i] = Math.random() * Math.PI * 2;
+    baseAlpha[i] = 0.15 + Math.random() * 0.08;
+  }
+
+  return {
+    pos,
+    dir,
+    driftSpeed,
+    driftOffset,
+    rotSpeed,
+    size,
+    kind,
+    filled,
+    aspect,
+    color,
+    breatheSpeed,
+    breathePhase,
+    baseAlpha,
+  };
+}
+
+export interface BackgroundRenderer {
+  resize(width: number, height: number): void;
+  frame(time: number): void;
+  destroy(): void;
+}
+
+const MAX_DPR = 1.5;
+const PIXEL_BUDGET = 750_000;
+
+export function computeCanvasSize(clientWidth: number, clientHeight: number) {
+  const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);
+  let width = Math.max(1, Math.floor(clientWidth * dpr));
+  let height = Math.max(1, Math.floor(clientHeight * dpr));
+  const pixels = width * height;
+  if (pixels > PIXEL_BUDGET) {
+    const k = Math.sqrt(PIXEL_BUDGET / pixels);
+    width = Math.max(1, Math.floor(width * k));
+    height = Math.max(1, Math.floor(height * k));
+  }
+  return { width, height };
+}

--- a/src/lib/webgl-background.ts
+++ b/src/lib/webgl-background.ts
@@ -1,0 +1,94 @@
+import fragSource from "~/shaders/bg.frag.glsl?raw";
+import vertSource from "~/shaders/bg.vert.glsl?raw";
+import type { BackgroundRenderer, ShapeParams } from "./background";
+
+export function createWebGLRenderer(
+  canvas: HTMLCanvasElement,
+  shapes: ShapeParams,
+  onLost: () => void,
+): BackgroundRenderer | null {
+  const gl = canvas.getContext("webgl2", {
+    alpha: false,
+    antialias: false,
+    preserveDrawingBuffer: false,
+  })!;
+  if (!gl) return null;
+
+  const onContextLost = (event: Event) => {
+    event.preventDefault();
+    onLost();
+  };
+  canvas.addEventListener("webglcontextlost", onContextLost);
+
+  function compile(type: number, source: string) {
+    const shader = gl.createShader(type);
+    if (!shader) return null;
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      console.error(gl.getShaderInfoLog(shader));
+      gl.deleteShader(shader);
+      return null;
+    }
+    return shader;
+  }
+
+  const vs = compile(gl.VERTEX_SHADER, vertSource);
+  const fs = compile(gl.FRAGMENT_SHADER, fragSource);
+  if (!vs || !fs) return null;
+
+  const prog = gl.createProgram();
+  if (!prog) return null;
+  gl.attachShader(prog, vs);
+  gl.attachShader(prog, fs);
+  gl.linkProgram(prog);
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    console.error(gl.getProgramInfoLog(prog));
+    return null;
+  }
+  gl.useProgram(prog);
+
+  const buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+  const aPos = gl.getAttribLocation(prog, "a_pos");
+  gl.enableVertexAttribArray(aPos);
+  gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+  const uniform = (name: string) => gl.getUniformLocation(prog, name);
+  const uTime = uniform("u_time");
+  const uRes = uniform("u_res");
+  gl.uniform2fv(uniform("u_pos"), shapes.pos);
+  gl.uniform2fv(uniform("u_dir"), shapes.dir);
+  gl.uniform1fv(uniform("u_driftSpeed"), shapes.driftSpeed);
+  gl.uniform1fv(uniform("u_driftOffset"), shapes.driftOffset);
+  gl.uniform1fv(uniform("u_rotSpeed"), shapes.rotSpeed);
+  gl.uniform1fv(uniform("u_size"), shapes.size);
+  gl.uniform1fv(uniform("u_kind"), shapes.kind);
+  gl.uniform1fv(uniform("u_filled"), shapes.filled);
+  gl.uniform2fv(uniform("u_aspect"), shapes.aspect);
+  gl.uniform3fv(uniform("u_color"), shapes.color);
+  gl.uniform1fv(uniform("u_breatheSpeed"), shapes.breatheSpeed);
+  gl.uniform1fv(uniform("u_breathePhase"), shapes.breathePhase);
+  gl.uniform1fv(uniform("u_baseAlpha"), shapes.baseAlpha);
+
+  return {
+    resize(width, height) {
+      canvas.width = width;
+      canvas.height = height;
+      gl.viewport(0, 0, width, height);
+      gl.uniform2f(uRes, width, height);
+    },
+    frame(time) {
+      gl.uniform1f(uTime, time);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    },
+    destroy() {
+      canvas.removeEventListener("webglcontextlost", onContextLost);
+      gl.deleteProgram(prog);
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      gl.deleteBuffer(buf);
+    },
+  };
+}

--- a/src/lib/webgpu-background.ts
+++ b/src/lib/webgpu-background.ts
@@ -1,0 +1,157 @@
+import fragSource from "~/shaders/bg.frag.wgsl?raw";
+import vertSource from "~/shaders/bg.vert.wgsl?raw";
+import type { BackgroundRenderer, ShapeParams } from "./background";
+import { N } from "./background";
+
+const RING = 3;
+const VEC4S_PER_SHAPE = 5;
+
+function packShapes(shapes: ShapeParams): Float32Array {
+  const flat = new Float32Array(N * VEC4S_PER_SHAPE * 4);
+  for (let i = 0; i < N; i++) {
+    const o = i * VEC4S_PER_SHAPE * 4;
+    flat[o] = shapes.pos[i * 2];
+    flat[o + 1] = shapes.pos[i * 2 + 1];
+    flat[o + 2] = shapes.dir[i * 2];
+    flat[o + 3] = shapes.dir[i * 2 + 1];
+    flat[o + 4] = shapes.driftSpeed[i];
+    flat[o + 5] = shapes.driftOffset[i];
+    flat[o + 6] = shapes.rotSpeed[i];
+    flat[o + 7] = shapes.size[i];
+    flat[o + 8] = shapes.kind[i];
+    flat[o + 9] = shapes.filled[i];
+    flat[o + 10] = shapes.aspect[i * 2];
+    flat[o + 11] = shapes.aspect[i * 2 + 1];
+    flat[o + 12] = shapes.color[i * 3];
+    flat[o + 13] = shapes.color[i * 3 + 1];
+    flat[o + 14] = shapes.color[i * 3 + 2];
+    flat[o + 15] = shapes.breatheSpeed[i];
+    flat[o + 16] = shapes.breathePhase[i];
+    flat[o + 17] = shapes.baseAlpha[i];
+  }
+  return flat;
+}
+
+export async function createWebGPURenderer(
+  canvas: HTMLCanvasElement,
+  shapes: ShapeParams,
+  onLost: () => void,
+): Promise<BackgroundRenderer | null> {
+  const adapter = await navigator.gpu?.requestAdapter();
+  if (!adapter) return null;
+
+  const device = await adapter.requestDevice();
+  const context = canvas.getContext("webgpu");
+  if (!context) return null;
+
+  let destroyed = false;
+  void device.lost.then(() => {
+    if (!destroyed) onLost();
+  });
+
+  const format = navigator.gpu.getPreferredCanvasFormat();
+
+  const vertModule = device.createShaderModule({ code: vertSource });
+  const fragModule = device.createShaderModule({ code: fragSource });
+
+  const bindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.FRAGMENT,
+        buffer: { type: "uniform", minBindingSize: 16 },
+      },
+      {
+        binding: 1,
+        visibility: GPUShaderStage.FRAGMENT,
+        buffer: { type: "uniform" },
+      },
+    ],
+  });
+
+  const pipeline = device.createRenderPipeline({
+    layout: device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] }),
+    vertex: { module: vertModule, entryPoint: "vs_main" },
+    fragment: {
+      module: fragModule,
+      entryPoint: "fs_main",
+      targets: [{ format }],
+    },
+    primitive: { topology: "triangle-list" },
+  });
+
+  const shapesData = packShapes(shapes);
+  const shapesBuffer = device.createBuffer({
+    size: shapesData.byteLength,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  });
+  device.queue.writeBuffer(shapesBuffer, 0, shapesData);
+
+  const frameBuffers = Array.from({ length: RING }, () =>
+    device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    }),
+  );
+  const bindGroups = frameBuffers.map((buffer) =>
+    device.createBindGroup({
+      layout: bindGroupLayout,
+      entries: [
+        { binding: 0, resource: { buffer } },
+        { binding: 1, resource: { buffer: shapesBuffer } },
+      ],
+    }),
+  );
+
+  const frameData = new Float32Array(4);
+  let frameIndex = 0;
+  let width = 0;
+  let height = 0;
+
+  return {
+    resize(w, h) {
+      width = w;
+      height = h;
+      canvas.width = w;
+      canvas.height = h;
+      context.configure({
+        device,
+        format,
+        alphaMode: "opaque",
+      });
+    },
+    frame(time) {
+      if (width === 0 || height === 0) return;
+      const slot = frameIndex % RING;
+      frameIndex++;
+      frameData[0] = time;
+      frameData[1] = width;
+      frameData[2] = height;
+      device.queue.writeBuffer(frameBuffers[slot], 0, frameData);
+
+      const view = context.getCurrentTexture().createView();
+      const encoder = device.createCommandEncoder();
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view,
+            loadOp: "clear",
+            storeOp: "store",
+            clearValue: { r: 1.0, g: 0.96, b: 0.94, a: 1.0 },
+          },
+        ],
+      });
+      pass.setPipeline(pipeline);
+      pass.setBindGroup(0, bindGroups[slot]);
+      pass.draw(3);
+      pass.end();
+      device.queue.submit([encoder.finish()]);
+    },
+    destroy() {
+      destroyed = true;
+      shapesBuffer.destroy();
+      frameBuffers.forEach((buffer) => buffer.destroy());
+      device.destroy();
+    },
+  };
+}

--- a/src/shaders/bg.frag.wgsl
+++ b/src/shaders/bg.frag.wgsl
@@ -1,12 +1,17 @@
+// Must stay in sync with N and VEC4S_PER_SHAPE in src/lib/webgpu-background.ts
+const N_SHAPES = 10u;
+const VEC4S_PER_SHAPE = 5u;
+const SHAPES_LEN = N_SHAPES * VEC4S_PER_SHAPE;
+
 // frame: time, res.x, res.y, 0
-// shapes: 5 vec4f per shape (see src/lib/webgpu-background.ts)
+// shapes: VEC4S_PER_SHAPE vec4f per shape
 //   v0 = pos.xy, dir.xy
 //   v1 = driftSpeed, driftOffset, rotSpeed, size
 //   v2 = kind, filled, aspect.x, aspect.y
 //   v3 = color.rgb, breatheSpeed
 //   v4 = breathePhase, baseAlpha, 0, 0
 @group(0) @binding(0) var<uniform> frame: vec4f;
-@group(0) @binding(1) var<uniform> shapes: array<vec4f, 50>;
+@group(0) @binding(1) var<uniform> shapes: array<vec4f, SHAPES_LEN>;
 
 fn fill(d: f32, w: f32) -> f32 {
   return 1.0 - smoothstep(0.0, w, d);
@@ -44,15 +49,17 @@ fn bg(uv: vec2f) -> vec3f {
 fn fs_main(@builtin(position) fragCoord: vec4f) -> @location(0) vec4f {
   let time = frame.x;
   let res = frame.yz;
-  let uv = fragCoord.xy / res;
+  // gl_FragCoord origin is bottom-left in GLSL, top-left in WebGPU; flip y so
+  // the WebGPU output matches the WebGL fallback.
+  let uv = vec2f(fragCoord.x, res.y - fragCoord.y) / res;
   let ar = res.x / res.y;
   let pAspect = vec2f(ar, 1.0);
   let aa = 1.0 / res.y;
 
   var col = bg(uv);
 
-  for (var i = 0u; i < 10u; i++) {
-    let b = i * 5u;
+  for (var i = 0u; i < N_SHAPES; i++) {
+    let b = i * VEC4S_PER_SHAPE;
     let pos = shapes[b].xy;
     let dir = shapes[b].zw;
     let dr = shapes[b + 1u];

--- a/src/shaders/bg.frag.wgsl
+++ b/src/shaders/bg.frag.wgsl
@@ -1,0 +1,95 @@
+// frame: time, res.x, res.y, 0
+// shapes: 5 vec4f per shape (see src/lib/webgpu-background.ts)
+//   v0 = pos.xy, dir.xy
+//   v1 = driftSpeed, driftOffset, rotSpeed, size
+//   v2 = kind, filled, aspect.x, aspect.y
+//   v3 = color.rgb, breatheSpeed
+//   v4 = breathePhase, baseAlpha, 0, 0
+@group(0) @binding(0) var<uniform> frame: vec4f;
+@group(0) @binding(1) var<uniform> shapes: array<vec4f, 50>;
+
+fn fill(d: f32, w: f32) -> f32 {
+  return 1.0 - smoothstep(0.0, w, d);
+}
+
+fn stroke(d: f32, w: f32, t: f32) -> f32 {
+  return fill(abs(d) - t, w);
+}
+
+fn sdTri(p: vec2f, r: f32) -> f32 {
+  let k = sqrt(3.0);
+  var q: vec2f = p;
+  q.x = abs(q.x) - r;
+  q.y = q.y + r / k;
+  if (q.x + k * q.y > 0.0) {
+    q = vec2f(q.x - k * q.y, -k * q.x - q.y) * 0.5;
+  }
+  q.x -= clamp(q.x, -2.0 * r, 0.0);
+  return -length(q) * sign(q.y);
+}
+
+fn sdDiamond(p: vec2f, r: f32) -> f32 {
+  return (abs(p.x) + abs(p.y) - r) * 0.7071;
+}
+
+fn bg(uv: vec2f) -> vec3f {
+  let g = dot(uv, vec2f(0.7071, -0.7071)) * 0.5 + 0.5;
+  let c0 = vec3f(1.0, 0.9608, 0.9412);
+  let c1 = vec3f(1.0, 0.9765, 0.9608);
+  let c2 = vec3f(1.0, 0.9412, 0.9608);
+  return mix(mix(c0, c1, smoothstep(0.0, 0.5, g)), c2, smoothstep(0.5, 1.0, g));
+}
+
+@fragment
+fn fs_main(@builtin(position) fragCoord: vec4f) -> @location(0) vec4f {
+  let time = frame.x;
+  let res = frame.yz;
+  let uv = fragCoord.xy / res;
+  let ar = res.x / res.y;
+  let pAspect = vec2f(ar, 1.0);
+  let aa = 1.0 / res.y;
+
+  var col = bg(uv);
+
+  for (var i = 0u; i < 10u; i++) {
+    let b = i * 5u;
+    let pos = shapes[b].xy;
+    let dir = shapes[b].zw;
+    let dr = shapes[b + 1u];
+    let ka = shapes[b + 2u];
+    let c4 = shapes[b + 3u];
+    let bp = shapes[b + 4u];
+
+    let t = time * dr.x + dr.y;
+    var p = uv - (pos + dir * t);
+    p = fract(p + 100.0) - 0.5;
+    p = p * pAspect;
+
+    let rot = time * dr.z;
+    let c = cos(rot);
+    let s = sin(rot);
+    p = mat2x2f(c, -s, s, c) * p;
+
+    var d: f32;
+    if (ka.x < 0.5) {
+      let a = ka.zw;
+      let scale = (a.x + a.y) * 0.5;
+      d = sdTri(p * a, dr.w * scale) / scale;
+    } else {
+      d = sdDiamond(p, dr.w);
+    }
+
+    var a: f32;
+    if (ka.y > 0.5) {
+      a = fill(d, aa);
+    } else {
+      a = stroke(d, aa, dr.w * 0.15);
+    }
+    a = a * (0.5 + 0.5 * sin(time * c4.w + bp.x));
+    a = a * bp.y;
+
+    col = mix(col, c4.xyz, a);
+  }
+
+  return vec4f(col, 1.0);
+}

--- a/src/shaders/bg.vert.wgsl
+++ b/src/shaders/bg.vert.wgsl
@@ -1,0 +1,15 @@
+struct VSOut {
+  @builtin(position) position: vec4f,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VSOut {
+  let pos = array<vec2f, 3>(
+    vec2f(-1.0, -1.0),
+    vec2f(3.0, -1.0),
+    vec2f(-1.0, 3.0),
+  );
+  var out: VSOut;
+  out.position = vec4f(pos[vi], 0.0, 1.0);
+  return out;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["unplugin-icons/types/react"],
+    "types": ["@webgpu/types", "unplugin-icons/types/react"],
     "ignoreDeprecations": "6.0"
   }
 }

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -5,6 +5,11 @@ declare module "*.glsl?raw" {
   export default content;
 }
 
+declare module "*.wgsl?raw" {
+  const content: string;
+  export default content;
+}
+
 declare module "*.css?url" {
   const url: string;
   export default url;


### PR DESCRIPTION
## Summary

Port the site background from WebGL2/GLSL to WebGPU/WGSL, keeping the existing GLSL renderer as a fallback for browsers without WebGPU (Firefox stable, older Safari).

## Changes

- **New WGSL shaders** (`src/shaders/bg.{vert,frag}.wgsl`) matching the original GLSL math (triangles/diamonds, drift, rotation, breathing, soft gradient).
- **WebGPU renderer** (`src/lib/webgpu-background.ts`): fullscreen triangle from `vertex_index` (no vertex buffer), static shapes in a single uniform buffer, and a triple-buffered per-frame time uniform so per-frame work is one 16-byte write + one submit.
- **WebGL2 fallback** (`src/lib/webgl-background.ts`): the original GLSL path extracted, now with `webglcontextlost` handling. When WebGPU loses its device twice, the canvas is remounted fresh so WebGL can take over (a canvas can only hold one context type).
- **Adaptive resolution** (`src/lib/background.ts`): DPR clamped at 1.5 with a 750K-pixel budget instead of the fixed 0.5x scale.
- **Loss recovery**: `device.lost` / `webglcontextlost` trigger teardown + re-init; per-frame exceptions can no longer silently kill the render loop.
- **Debounced resize**: small viewport changes during scroll (mobile URL bar) no longer rebuild the buffer per event, fixing shapes jumping up/down while scrolling.

## Verification

- `pnpm build` passes; lint + typecheck clean for all touched files.
- Verified live in a real browser: WGSL compiles, pipeline builds, no validation errors, correct pixel output, and the ring-buffer loop runs multiple frames with zero GPU errors.
- Manual QA on desktop Chrome (WebGPU) and an Android phone via Tailscale HTTPS.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Port animated canvas background to WebGPU with WebGL2 fallback
> - Rewrites [`CanvasBackground`](https://github.com/elianiva/elianiva.com/pull/89/files#diff-11531ee18a52cfd39be60ebb3c6ad7df55a49fc29cb81562663f8fd4dccf4256) to try WebGPU first, falling back to WebGL2 on init failure or runtime device/context loss; after repeated losses it permanently switches to WebGL.
> - Adds [`createWebGPURenderer`](https://github.com/elianiva/elianiva.com/pull/89/files#diff-f6d80bc5061b725555b9c53e08163e339815410b9c22c2192f277305c02b1f2e) (WGSL shaders, per-frame uniform ring buffer) and [`createWebGLRenderer`](https://github.com/elianiva/elianiva.com/pull/89/files#diff-a892b2d11c797b8693cea8b0cbbcdaadbfdd645b72d3d042f8024f46dd0aaccd) (GLSL shaders, fullscreen triangle VBO), both implementing a common `BackgroundRenderer` interface.
> - Shape generation and canvas sizing are extracted to [`src/lib/background.ts`](https://github.com/elianiva/elianiva.com/pull/89/files#diff-0c421a58f16fcf3d9c5fe85b877893bd3e70baf8542246e734a4be7fae1273a5); canvas resolution is capped at DPR 1.5 and a 750k-pixel budget, and small resize changes are deferred to avoid jitter during mobile URL-bar scroll.
> - Rendering is capped at 30 FPS; `prefers-reduced-motion` renders a static frame (time=0); an `IntersectionObserver` pauses the RAF loop when the canvas is off-screen.
> - Behavioral Change: resolution scaling, FPS cap, and reduced-motion behavior all differ from the previous implementation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0959b4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->